### PR TITLE
Fracday bugfix

### DIFF
--- a/bin/mkmf.template.nci
+++ b/bin/mkmf.template.nci
@@ -6,11 +6,12 @@ LIB_NETCDF := $(shell nc-config --flibs)
 MPI_INC := -I${FPATH} $(shell mpif90 -showme:compiler)
 LIB_MPI := -L${OMPI_F90LIBS} $(shell mpif90 -showme:link)
 
-FFLAGS = -fpp -stack_temps -safe_cray_ptr -ftz -i-dynamic -assume byterecl -i4 -r8 -g -I${NETCDF_INC} ${MPI_INC}
+FFLAGS = -fpp -stack_temps -safe-cray-ptr -ftz -i-dynamic -assume byterecl -i4 -r8 -g -I${NETCDF_INC} ${MPI_INC}
 #FFLAGS = ${DEBUG} -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -O3 -axAVX -xSSE2 -ipo -i4 -r8 -g ${INC_NETCDF} -I${MVAPICH2_INC}
 #FFLAGS = ${DEBUG} -stack_temps -safe_cray_ptr -ftz -i_dynamic -assume byterecl -O0 -i4 -r8 -g -I${NETCDF_INC} -I${MVAPICH2_INC}
 #OPT = -O2 -xSSE4.2 -axAVX
-OPT = -O2
+OPT = -O2 -ip -fpe0
+#OPT = -O2
 #OPT = -O1 
 #OPT = -O0
 

--- a/src/atmos_param/rrtm_radiation/astro.f90
+++ b/src/atmos_param/rrtm_radiation/astro.f90
@@ -75,12 +75,12 @@ module rrtm_astro
             integer(kind=im)            ,intent(out):: dyofyr      ! day of the year to compute cosz at
 ! Locals
             real(kind=rb),dimension(size(lat,1),size(lat,2)) :: h,cos_h, &
-                 lat_h,fracday
+                 lat_h
 
-            real dec_sin,dec_tan,dec,dec_cos,twopi,dt_pi
+            real     :: dec_sin,dec_tan,dec,dec_cos,twopi,dt_pi
 
             integer  :: seconds,sec2,days,daysperyear
-            real,dimension(size(lon,1),size(lon,2)) :: time_pi,aa,bb,tt,st,stt,sh
+            real,dimension(size(lon,1),size(lon,2)) :: time_pi,aa,bb,tt,st,stt,sh,fracday
             real     :: radsec,radday
 
             integer  :: i,j
@@ -223,7 +223,7 @@ module rrtm_astro
 !    now we need to correct cosz by the fraction of day when 
 !     averaging
 !-------------------------------------------------------------------
-               cosz = cosz*fracday
+               cosz = cosz*fracday/radpersec
 !-------------------------------------------------------------------
 !    daily mean
 !-------------------------------------------------------------------

--- a/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
+++ b/src/atmos_param/rrtm_radiation/rrtm_radiation.f90
@@ -488,7 +488,7 @@
           integer k,j,i,ij,j1,i1,ij1,kend,dyofyr,seconds,days
           integer si,sj,sk,locmin(3)
           real(kind=rb),dimension(size(q,1),size(q,2),size(q,3)) :: o3f
-          real(kind=rb),dimension(ncols_rrt,nlay_rrt) :: pfull,tfull,fracday&
+          real(kind=rb),dimension(ncols_rrt,nlay_rrt) :: pfull,tfull&
                , hr,hrc, swhr, swhrc
           real(kind=rb),dimension(size(tdt,1),size(tdt,2),size(tdt,3)) :: tdt_rrtm
           real(kind=rb),dimension(ncols_rrt,nlay_rrt+1) :: uflx, dflx, uflxc, dflxc&


### PR DESCRIPTION
In astro.f90, there is a slight inconcistency with the computation of the cosine of zenith angle, coszen: If one wants to average over a given radiation step, the computed coszen has to be multiplied by the fraction of time a given grid point sees daylight, i.e. fracday. This is corrected now, thanks to Stephen Thomson from Exeter Uni.