### PR TITLE
Input file calendar adjustment

### DIFF
--- a/src/atmos_shared/interpolator/interpolator.F90
+++ b/src/atmos_shared/interpolator/interpolator.F90
@@ -297,6 +297,10 @@ nlevh = 1
 do i = 1, ndim
   call mpp_get_atts(axes(i), name=name,len=len,units=units,  &
                     calendar=file_calendar, sense=sense)
+  !mj if we want to use a previous output file as an input file
+  ! (eg to force the model), the calendar might be "360", which
+  ! is another way of saying "thirty_day_months"
+  if ( trim(file_calendar) .eq. '360' ) file_calendar = 'thirty_day_months'
   select case(name)
     case('lat')
       nlat=len


### PR DESCRIPTION
As is, if we use an output file from a previous run which was using a
360-day, thirty-day-months calendar, the calendar attribute within the
file will be `”360”`. Unfortunately, that calendar does not work for
input files, if the model calendar is set to `”thirty_day_months”`.
This fix makes sure that a `360` calendar is treated as
`thirty_day_months`.