### PR TITLE
land-sea mask from navy files

### DIFF
--- a/src/atmos_spectral/driver/coupled/atmosphere.f90
+++ b/src/atmos_spectral/driver/coupled/atmosphere.f90
@@ -19,7 +19,9 @@ use         constants_mod, only: grav
 
 use        transforms_mod, only: trans_grid_to_spherical, trans_spherical_to_grid, get_deg_lon, get_deg_lat, &
                                  get_wts_lat, get_grid_boundaries, compute_ucos_vcos, divide_by_cos, get_lon_max, &
-                                 get_lat_max, get_grid_domain, grid_domain
+                                 get_lat_max, get_grid_domain
+
+use           spec_mpp_mod,only: grid_domain
 
 use  press_and_geopot_mod, only: pressure_variables, compute_pressures_and_heights, compute_z_bot
 

--- a/src/atmos_spectral/driver/coupled/spectral_physics.f90
+++ b/src/atmos_spectral/driver/coupled/spectral_physics.f90
@@ -10,7 +10,9 @@ use time_manager_mod,      only: time_type, set_time, get_time, operator(-), ope
 use press_and_geopot_mod,  only: pressure_variables, compute_pressures_and_heights
 
 use transforms_mod,        only: get_grid_boundaries, get_deg_lon, get_deg_lat, get_wts_lat, &
-                                 get_grid_domain, get_lon_max, get_lat_max, grid_domain
+                                 get_grid_domain, get_lon_max, get_lat_max
+
+use           spec_mpp_mod,only: grid_domain
 
 use spectral_dynamics_mod, only: get_reference_sea_level_press, get_num_levels
 

--- a/src/atmos_spectral/init/spectral_init_cond.f90
+++ b/src/atmos_spectral/init/spectral_init_cond.f90
@@ -12,8 +12,8 @@ use         constants_mod, only: grav, pi
 use   vert_coordinate_mod, only: compute_vert_coord
 
 use        transforms_mod, only: get_grid_boundaries, get_deg_lon, get_deg_lat, trans_grid_to_spherical, &
-                                 trans_spherical_to_grid, grid_domain, spectral_domain, get_grid_domain, &
-                                 get_spec_domain
+                                 trans_spherical_to_grid, get_grid_domain, get_spec_domain 
+use           spec_mpp_mod,only: grid_domain, spectral_domain
 
 use  press_and_geopot_mod, only: press_and_geopot_init, pressure_variables
 

--- a/src/atmos_spectral/init/topog_regularization.f90
+++ b/src/atmos_spectral/init/topog_regularization.f90
@@ -18,7 +18,9 @@ use      transforms_mod, only: compute_gaussian, compute_legendre, &
                                get_sin_lat, get_wts_lat, transforms_are_initialized,      &
                                get_lon_max, get_lat_max, get_num_fourier, get_fourier_inc,&
                                get_num_spherical, get_grid_domain, get_spec_domain,       &
-                               grid_domain, spectral_domain, area_weighted_global_mean
+                               area_weighted_global_mean
+
+use         spec_mpp_mod,only: grid_domain, spectral_domain
 
 use     mpp_domains_mod, only: mpp_global_field
 

--- a/src/atmos_spectral/model/every_step_diagnostics.f90
+++ b/src/atmos_spectral/model/every_step_diagnostics.f90
@@ -12,7 +12,8 @@ use     diag_manager_mod, only: diag_axis_init, register_diag_field, register_st
 
 use press_and_geopot_mod, only: pressure_variables
 
-use       transforms_mod, only: grid_domain, get_deg_lon, get_deg_lat, get_grid_domain
+use       transforms_mod, only: get_deg_lon, get_deg_lat, get_grid_domain
+use          spec_mpp_mod,only: grid_domain
 
 use        constants_mod, only: hlv, cp_air, grav, kappa, rvgas, rdgas, &
                                 RADIUS, RADIAN, OMEGA !mj

--- a/src/atmos_spectral/model/spectral_dynamics.f90
+++ b/src/atmos_spectral/model/spectral_dynamics.f90
@@ -26,8 +26,8 @@ use         transforms_mod, only: transforms_init,         transforms_end,      
                                   get_spherical_wave,      get_sin_lat,               &
                                   vor_div_from_uv_grid,    uv_grid_from_vor_div,      &
                                   horizontal_advection,    get_grid_domain,           &
-                                  get_spec_domain,         grid_domain,               &
-                                  spectral_domain,         get_deg_lon, get_deg_lat
+                                  get_spec_domain,         get_deg_lon, get_deg_lat
+use            spec_mpp_mod,only: grid_domain, spectral_domain
 
 use     vert_advection_mod, only: vert_advection, SECOND_CENTERED, FOURTH_CENTERED, VAN_LEER_LINEAR, FINITE_VOLUME_PARABOLIC, &
                                   ADVECTIVE_FORM


### PR DESCRIPTION
Much easier than an additional external file, with `land_option = 'interpolated'` one can now use the navy topography data as land-sea mask.