### PR TITLE
small fix that gets round a bug in cmake/ifort latest versions

### DIFF
--- a/src/shared/fft/fft.F90
+++ b/src/shared/fft/fft.F90
@@ -43,10 +43,8 @@ module fft_mod
 use platform_mod, only: R8_KIND, R4_KIND
 use      fms_mod, only: write_version_number,  &
                         error_mesg, FATAL
-#ifndef SGICRAY
-#ifndef NAGFFT
+#if !defined(SGICRAY) && !defined(NAGFFT)
 use    fft99_mod, only: fft991, set99
-#endif
 #endif
 
 implicit none


### PR DESCRIPTION
This doesn't change the meaning of the C pre-processor, but it avoids a bug we found with ifort when trying to interface with the cmake build system.